### PR TITLE
fix docker ci failure2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+env
+.github
+.gitignore

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:22.04 AS base
-ENV NODE_ENV=production
 RUN apt-get update && \
     apt-get upgrade --no-install-recommends -y && \
     apt-get install --no-install-recommends -y curl ca-certificates dumb-init && \
@@ -27,9 +26,11 @@ WORKDIR /builder/dist
 
 
 FROM base AS app
+ENV NODE_ENV=production
 RUN groupadd -g 1234 node && \
     useradd -m -u 1234 -g node node
 COPY --from=builder --chown=node:node /builder/dist /app
 USER node
 WORKDIR /app
-CMD ["dumb-init", "node", "index.js"]
+#CMD ["dumb-init", "node", "index.js"]
+CMD ["dumb-init", "node", "dbtest.js"]

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5.6.3"
   },
   "scripts": {
-    "build": "npx tsc -p ./tsconfig.build.json && npx tsc-alias -p tsconfig.build.json && node -e \"require('fs-extra').copySync('./src', './dist', { filter: (src) => (!src.endsWith('.ts') && !src.endsWith('.js'))})\"",
+    "build": "tsc -p ./tsconfig.build.json && tsc-alias -p tsconfig.build.json && node -e \"require('fs-extra').copySync('./src', './dist', { filter: (src) => (!src.endsWith('.ts') && !src.endsWith('.js'))})\"",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
ENV NODE_ENV=productionによってyarn installしたときにtscなどがインストールされなかった
ローカルのnode_modulesもCOPY ./ ./の時に取り込んでしまいローカルでは正常に実行されてしまった

ENV NODE_ENV=productionをビルド以降に移動
.dockerignoreを追加
https://github.com/AkatukiSora/activity_bot/commit/a6bd6e1c1376d8a05d7285e061f654b5409a32e4#commitcomment-148622843